### PR TITLE
Fix lint verifier error in molecule

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,6 +6,7 @@ driver:
 lint: |
   set -e
   yamllint -s .
+  flake8 .
 platforms:
   - name: instance
     image: 'geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest'
@@ -24,5 +25,3 @@ scenario:
   name: default
 verifier:
   name: testinfra
-  lint:
-    name: flake8


### PR DESCRIPTION
In later versions of molecule the lint verifier is deprecated. Running `molecule test` results in the following error:
```
akraker@akraker-ThinkPad-X1-Carbon-Gen-9:~/ansible.users$ molecule test
CRITICAL Failed to validate /home/akraker/ansible.users/molecule/default/molecule.yml

["Additional properties are not allowed ('lint' was unexpected)"]
```
This fixes that error while preserving use of flake8 for linting.